### PR TITLE
[RFC] Make luarocks compatible

### DIFF
--- a/lib/body.lua
+++ b/lib/body.lua
@@ -7,8 +7,8 @@ local vector      = require(_PACKAGE..'/vector')
 local body        = {}
 body.__index = body
 
-body.glowShader     = love.graphics.newShader(_PACKAGE.."/shaders/glow.glsl")
-body.materialShader = love.graphics.newShader(_PACKAGE.."/shaders/material.glsl")
+body.glowShader     = love.graphics.newShader(require(_PACKAGE..".shaders.glow"))
+body.materialShader = love.graphics.newShader(require(_PACKAGE..".shaders.material"))
 
 local function new(id, type, ...)
 	local args = {...}

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -31,10 +31,10 @@ local PostShader = require(_PACKAGE..'postshader')
 local light_world = {}
 light_world.__index = light_world
 
-light_world.image_mask       = love.graphics.newShader(_PACKAGE.."/shaders/image_mask.glsl")
-light_world.shadowShader     = love.graphics.newShader(_PACKAGE.."/shaders/shadow.glsl")
-light_world.refractionShader = love.graphics.newShader(_PACKAGE.."shaders/refraction.glsl")
-light_world.reflectionShader = love.graphics.newShader(_PACKAGE.."shaders/reflection.glsl")
+light_world.image_mask       = love.graphics.newShader(require(_PACKAGE.."shaders.image_mask"))
+light_world.shadowShader     = love.graphics.newShader(require(_PACKAGE.."shaders.shadow"))
+light_world.refractionShader = love.graphics.newShader(require(_PACKAGE.."shaders.refraction"))
+light_world.reflectionShader = love.graphics.newShader(require(_PACKAGE.."shaders.reflection"))
 
 local function new(options)
   local obj = {}

--- a/lib/postshader.lua
+++ b/lib/postshader.lua
@@ -27,24 +27,8 @@ local util = require(_PACKAGE..'/util')
 local post_shader = {}
 post_shader.__index = post_shader
 
-local files = love.filesystem.getDirectoryItems(_PACKAGE.."/shaders/postshaders")
-local shaders = {}
+local shaders = require(_PACKAGE..'.shaders.postshaders')
 	
-for i,v in ipairs(files) do
-  local name = _PACKAGE.."/shaders/postshaders/"..v
-  local module = _PACKAGE..".shaders.postshaders."..v:gsub("%.lua","")
-  if love.filesystem.isFile(name) then
-    local str = love.filesystem.read(name)
-    local effect = love.graphics.newShader(require(module))
-    local defs = {}
-    for vtype, extern in str:gmatch("extern (%w+) (%w+)") do
-      defs[extern] = true
-    end
-    local shaderName = name:match(".-([^\\|/]-[^%.]+)$"):gsub("%.lua", "")
-    shaders[shaderName] = {effect, defs}
-  end
-end
-
 local function new()
   local obj = {effects = {}}
   local class = setmetatable(obj, post_shader)

--- a/lib/postshader.lua
+++ b/lib/postshader.lua
@@ -31,15 +31,16 @@ local files = love.filesystem.getDirectoryItems(_PACKAGE.."/shaders/postshaders"
 local shaders = {}
 	
 for i,v in ipairs(files) do
-  local name = _PACKAGE.."/shaders/postshaders".."/"..v
+  local name = _PACKAGE.."/shaders/postshaders/"..v
+  local module = _PACKAGE..".shaders.postshaders."..v:gsub("%.lua","")
   if love.filesystem.isFile(name) then
     local str = love.filesystem.read(name)
-    local effect = love.graphics.newShader(name)
+    local effect = love.graphics.newShader(require(module))
     local defs = {}
     for vtype, extern in str:gmatch("extern (%w+) (%w+)") do
       defs[extern] = true
     end
-    local shaderName = name:match(".-([^\\|/]-[^%.]+)$"):gsub("%.glsl", "")
+    local shaderName = name:match(".-([^\\|/]-[^%.]+)$"):gsub("%.lua", "")
     shaders[shaderName] = {effect, defs}
   end
 end

--- a/lib/shaders/glow.lua
+++ b/lib/shaders/glow.lua
@@ -1,3 +1,4 @@
+return [[//
 extern Image glowImage;
 extern float glowTime;
 
@@ -17,3 +18,4 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
 	
 	return vec4(Texel(texture, texture_coords).rgb * glowInfo.r, 1.0);
 }
+]]

--- a/lib/shaders/image_mask.lua
+++ b/lib/shaders/image_mask.lua
@@ -1,6 +1,8 @@
+return [[//
 //https://love2d.org/wiki/love.graphics.setStencil image mask
 vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 screen_coords) {
   if (Texel(texture, texture_coords).rgb == vec3(0.0))
     discard;
   return vec4(1.0);
 }
+]]

--- a/lib/shaders/material.lua
+++ b/lib/shaders/material.lua
@@ -1,3 +1,4 @@
+return [[//
 extern Image material;
 
 vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
@@ -8,3 +9,4 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
 		return vec4(0.0);
 	}
 }
+]]

--- a/lib/shaders/postshaders/black_and_white.lua
+++ b/lib/shaders/postshaders/black_and_white.lua
@@ -1,13 +1,15 @@
+return [[//
 extern float exposure = 0.7;
 extern float brightness = 1.0;
 extern vec3 lumacomponents = vec3(1.0, 1.0, 1.0);
 const vec3 lumcoeff = vec3(0.212671, 0.715160, 0.072169);
 
-vec4 effect(vec4 vcolor, Image texture, vec2 texcoord, vec2 pixel_coords) {	
+vec4 effect(vec4 vcolor, Image texture, vec2 texcoord, vec2 pixel_coords) {
 	vec4 input0 = Texel(texture, texcoord);
 	input0 *= (exp2(input0)*vec4(exposure));
 	vec4 lumacomponents = vec4(lumcoeff * lumacomponents, 0.0 );
 	float luminance = dot(input0,lumacomponents);
 	vec4 luma = vec4(luminance);
 	return vec4(luma.rgb * brightness, 1.0);
-} 
+}
+]]

--- a/lib/shaders/postshaders/blurh.lua
+++ b/lib/shaders/postshaders/blurh.lua
@@ -1,12 +1,14 @@
+return [[//
 extern float steps = 2.0;
 
 vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
 	vec2 pSize = vec2(1.0 / love_ScreenSize.x, 1.0 / love_ScreenSize.y);
 	vec4 col = Texel(texture, texture_coords);
 	for(int i = 1; i <= steps; i++) {
-		col = col + Texel(texture, vec2(texture_coords.x - pSize.x * i, texture_coords.y));
-		col = col + Texel(texture, vec2(texture_coords.x + pSize.x * i, texture_coords.y));
+		col = col + Texel(texture, vec2(texture_coords.x, texture_coords.y - pSize.y * i));
+		col = col + Texel(texture, vec2(texture_coords.x, texture_coords.y + pSize.y * i));
 	}
 	col = col / (steps * 2.0 + 1.0);
 	return vec4(col.r, col.g, col.b, 1.0);
 }
+]]

--- a/lib/shaders/postshaders/blurv.lua
+++ b/lib/shaders/postshaders/blurv.lua
@@ -1,12 +1,14 @@
+return [[//
 extern float steps = 2.0;
 
 vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
 	vec2 pSize = vec2(1.0 / love_ScreenSize.x, 1.0 / love_ScreenSize.y);
 	vec4 col = Texel(texture, texture_coords);
 	for(int i = 1; i <= steps; i++) {
-		col = col + Texel(texture, vec2(texture_coords.x, texture_coords.y - pSize.y * i));
-		col = col + Texel(texture, vec2(texture_coords.x, texture_coords.y + pSize.y * i));
+		col = col + Texel(texture, vec2(texture_coords.x - pSize.x * i, texture_coords.y));
+		col = col + Texel(texture, vec2(texture_coords.x + pSize.x * i, texture_coords.y));
 	}
 	col = col / (steps * 2.0 + 1.0);
 	return vec4(col.r, col.g, col.b, 1.0);
 }
+]]

--- a/lib/shaders/postshaders/chromatic_aberration.lua
+++ b/lib/shaders/postshaders/chromatic_aberration.lua
@@ -1,3 +1,4 @@
+return [[//
 extern vec2 redStrength = vec2(4.0, 3.0);
 extern vec2 greenStrength = vec2(-2.0, -1.0);
 extern vec2 blueStrength = vec2(1.0, -3.0);
@@ -10,3 +11,4 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
 
 	return vec4(colRed, colGreen, colBlue, 1.0);
 }
+]]

--- a/lib/shaders/postshaders/contrast.lua
+++ b/lib/shaders/postshaders/contrast.lua
@@ -1,5 +1,7 @@
+return [[//
 vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
 	vec3 col = Texel(texture, texture_coords).rgb * 2.0;
 	col *= col;
 	return vec4(col, 1.0);
 }
+]]

--- a/lib/shaders/postshaders/curvature.lua
+++ b/lib/shaders/postshaders/curvature.lua
@@ -1,3 +1,4 @@
+return [[//
 #define distortion 0.2
 vec2 radialDistortion(vec2 coord) {
   vec2 cc = coord - 0.5;
@@ -16,3 +17,4 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
   texcolor.a = 1.0;
   return texcolor;
 }
+]]

--- a/lib/shaders/postshaders/edges.lua
+++ b/lib/shaders/postshaders/edges.lua
@@ -1,8 +1,9 @@
+return [[//
 /*
     Edge shader
     Author: Themaister
     License: Public domain.
-    
+
     modified by slime73 for use with love2d and mari0
 */
 
@@ -10,7 +11,7 @@ vec3 grayscale(vec3 color)
 {
 	return vec3(dot(color, vec3(0.3, 0.59, 0.11)));
 }
- 
+
 vec4 effect(vec4 vcolor, Image texture, vec2 tex, vec2 pixel_coords)
 {
 	vec4 texcolor = Texel(texture, tex);
@@ -35,5 +36,4 @@ vec4 effect(vec4 vcolor, Image texture, vec2 tex, vec2 pixel_coords)
 	vec4 final = vec4(5.0 * grayscale(abs(res - c11)), 1.0);
 	return clamp(final, 0.0, 1.0);
 }
-
-
+]]

--- a/lib/shaders/postshaders/four_colors.lua
+++ b/lib/shaders/postshaders/four_colors.lua
@@ -1,3 +1,4 @@
+return [[//
 extern vec3 palette[4];
 
 vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords){
@@ -6,3 +7,4 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords){
 
 	return vec4(palette[index], 1.0);
 }
+]]

--- a/lib/shaders/postshaders/hdr_tv.lua
+++ b/lib/shaders/postshaders/hdr_tv.lua
@@ -1,8 +1,10 @@
+return [[//
 vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
 	vec4 rgb = Texel(texture, texture_coords);
 	vec4 intens = smoothstep(0.2,0.8,rgb) + normalize(vec4(rgb.xyz, 1.0));
 
 	if (fract(pixel_coords.y * 0.5) > 0.5) intens = rgb * 0.8;
 	intens.a = 1.0;
-    return intens;
+	return intens;
 }
+]]

--- a/lib/shaders/postshaders/init.lua
+++ b/lib/shaders/postshaders/init.lua
@@ -1,0 +1,63 @@
+--[[
+The MIT License (MIT)
+
+Copyright (c) 2016 Marcus Ihde
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+]]
+local _PACKAGE = (...)
+
+-- Since require() doesn't support enumeration we automatically populate the
+-- shader list using
+-- for f in lib/shaders/postshaders/*.lua; echo \"`basename $f .lua`\",
+-- and manually remove init.lua
+local names = {
+"black_and_white",
+"blurh",
+"blurv",
+"chromatic_aberration",
+"contrast",
+"curvature",
+"edges",
+"four_colors",
+"hdr_tv",
+"monochrome",
+"phosphorish",
+"phosphor",
+"pip",
+"pixellate",
+"radialblur",
+"scanlines",
+"tilt_shift",
+"waterpaint",
+}
+
+local shaders = {}
+for _, name in ipairs(names) do
+  local module = _PACKAGE.."."..v
+  local str = require(module)
+  local effect = love.graphics.newShader(str)
+  local defs = {}
+  for vtype, extern in str:gmatch("extern (%w+) (%w+)") do
+    defs[extern] = true
+  end
+  shaders[name] = {effect, defs}
+end
+
+return shaders

--- a/lib/shaders/postshaders/monochrome.lua
+++ b/lib/shaders/postshaders/monochrome.lua
@@ -1,9 +1,10 @@
+return [[//
 extern float time = 0.0;
 extern vec3 tint = vec3(1.0, 1.0, 1.0);
 extern float fudge = 0.1;
 
 float rand(vec2 position, float seed) {
-   return fract(sin(dot(position.xy,vec2(12.9898, 78.233))) * seed);
+	return fract(sin(dot(position.xy,vec2(12.9898, 78.233))) * seed);
 }
 
 vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords){
@@ -11,3 +12,4 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords){
 	float intensity = (pixel.r + pixel.g + pixel.b) / 3.0 + (rand(texture_coords, time) - 0.5) * fudge;
 	return vec4(intensity * tint.r, intensity * tint.g, intensity * tint.b, 1.0);
 }
+]]

--- a/lib/shaders/postshaders/phosphor.lua
+++ b/lib/shaders/postshaders/phosphor.lua
@@ -1,3 +1,4 @@
+return [[//
 /*
 	caligari's scanlines
 
@@ -13,7 +14,7 @@
 
 		http://board.byuu.org/viewtopic.php?p=36219#p36219
 
-		"As I said to Hyllian by PM, I'm fine with the GPL (not really a bi
+		"As I said to Hyllian by PM, I'm fine with the GPL (not really a big
 		deal...)"
    )
 */
@@ -155,3 +156,4 @@ vec4 effect(vec4 vcolor, Image texture, vec2 texCoord, vec2 pixel_coords)
 
 	return clamp(GAMMA_OUT(color), 0.0, 1.0);
 }
+]]

--- a/lib/shaders/postshaders/phosphorish.lua
+++ b/lib/shaders/postshaders/phosphorish.lua
@@ -1,3 +1,4 @@
+return [[//
 /*
    Plain (and obviously inaccurate) phosphor.
    Author: Themaister
@@ -42,4 +43,4 @@ vec4 effect(vec4 vcolor, Image texture, vec2 texture_coords, vec2 pixel_coords)
 
 	return vec4(intensity * result, 1.0);
 }
-
+]]

--- a/lib/shaders/postshaders/pip.lua
+++ b/lib/shaders/postshaders/pip.lua
@@ -1,3 +1,4 @@
+return [[//
 #define glarebasesize 0.896
 #define power 0.50
 extern float time;
@@ -12,7 +13,7 @@ float luminance(vec3 color)
 float scanline(float ypos)
 {
 
-	float c = mod(time * 3.0 + ypos * 5.0, 15.0);	
+	float c = mod(time * 3.0 + ypos * 5.0, 15.0);
 	return 1.0 - smoothstep(0.0, 1.0, c);
 }
 
@@ -35,7 +36,7 @@ vec4 effect(vec4 vcolor, Image texture, vec2 texcoord, vec2 pixel_coords)
 		for (j = -1; j < 1; j++)
 		{
 			sum += Texel(texture, texcoord + vec2(-i, j)*glaresize) * power;
-			bum += Texel(texture, texcoord + vec2(j, i)*glaresize) * power;            
+			bum += Texel(texture, texcoord + vec2(j, i)*glaresize) * power;
 		}
 	}
 	
@@ -59,4 +60,4 @@ vec4 effect(vec4 vcolor, Image texture, vec2 texcoord, vec2 pixel_coords)
 	
 	return finalcolor;
 }
-
+]]

--- a/lib/shaders/postshaders/pixellate.lua
+++ b/lib/shaders/postshaders/pixellate.lua
@@ -1,3 +1,4 @@
+return [[//
 const float pixel_w = 2.0;
 const float pixel_h = 2.0;
 
@@ -8,3 +9,4 @@ vec4 effect(vec4 vcolor, Image texture, vec2 uv, vec2 pixel_coords)
 	vec2 coord = vec2(dx*floor(uv.x/dx), dy*floor(uv.y/dy));
 	return Texel(texture, coord);
 }
+]]

--- a/lib/shaders/postshaders/radialblur.lua
+++ b/lib/shaders/postshaders/radialblur.lua
@@ -1,3 +1,4 @@
+return [[//
 #define nsamples 5
 extern number blurstart = 1.0; // 0 to 1
 extern number blurwidth = -0.02; // -1 to 1
@@ -18,3 +19,4 @@ vec4 effect(vec4 vcolor, Image texture, vec2 texture_coords, vec2 pixel_coords)
 	
 	return c;
 }
+]]

--- a/lib/shaders/postshaders/scanlines.lua
+++ b/lib/shaders/postshaders/scanlines.lua
@@ -1,3 +1,4 @@
+return [[//
 extern float strength = 2.0;
 extern float time = 0.0;
 
@@ -30,3 +31,4 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords){
 		return vec4(vec3(red * 0.75, green * 0.75, blue * 0.75) * brightness, 1.0);
 	}
 }
+]]

--- a/lib/shaders/postshaders/tilt_shift.lua
+++ b/lib/shaders/postshaders/tilt_shift.lua
@@ -1,3 +1,4 @@
+return [[//
 extern Image imgBuffer;
 
 vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords){
@@ -10,3 +11,4 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords){
 		return vec4(pixel.rgb * (0.5 - texture_coords.y) * 2.0 + pixelBuffer.rgb * texture_coords.y * 2.0, 1.0);
 	}
 }
+]]

--- a/lib/shaders/postshaders/waterpaint.lua
+++ b/lib/shaders/postshaders/waterpaint.lua
@@ -1,22 +1,23 @@
+return [[//
 /*
      Themaister's Waterpaint shader
 
-     Placed in the public domain. 
+     Placed in the public domain.
 
      (From this thread: http://board.byuu.org/viewtopic.php?p=30483#p30483 
      PD declaration here: http://board.byuu.org/viewtopic.php?p=30542#p30542 )
-     
+
      modified by slime73 for use with love2d and mari0
 */
 
- 
+
 vec4 compress(vec4 in_color, float threshold, float ratio)
 {
 	vec4 diff = in_color - vec4(threshold);
 	diff = clamp(diff, 0.0, 100.0);
 	return in_color - (diff * (1.0 - 1.0/ratio));
 }
- 
+
 vec4 effect(vec4 vcolor, Image texture, vec2 tex, vec2 pixel_coords)
 {
 	float x = 0.5 * (1.0 / love_ScreenSize.x);
@@ -53,3 +54,4 @@ vec4 effect(vec4 vcolor, Image texture, vec2 tex, vec2 pixel_coords)
 	
 	return final;
 }
+]]

--- a/lib/shaders/reflection.lua
+++ b/lib/shaders/reflection.lua
@@ -1,3 +1,4 @@
+return [[//
 extern Image backBuffer;
 
 extern float reflectionStrength;
@@ -21,3 +22,4 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
 		return vec4(0.0);
 	}
 }
+]]

--- a/lib/shaders/refraction.lua
+++ b/lib/shaders/refraction.lua
@@ -1,3 +1,4 @@
+return [[//
 extern Image backBuffer;
 
 extern float refractionStrength = 1.0;
@@ -16,3 +17,4 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
 		return vec4(0.0);
 	}
 }
+]]

--- a/lib/shaders/shadow.lua
+++ b/lib/shaders/shadow.lua
@@ -1,3 +1,4 @@
+return [[//
 /*
     Copyright (c) 2014 Tim Anema
     light shadow, shine and normal shader all in one
@@ -47,4 +48,4 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 pixel_coords) {
     return pixel;
   }
 }
-
+]]


### PR DESCRIPTION
Most of these changes are so I can make a [Loverocks](https://github.com/alloyed/loverocks) package for light_world.

The core problem is that luarocks can only handle lua modules: anything else falls outside of its scope. So instead of shipping shaders as glsl files, we ship lua modules that hold the glsl as a string and we pull it in using the same require() mechanism we use for normal lua.
### Pros
- Tools like luarocks, luacheck, squish etc. can "understand" glsl modules without special code
- Automatic interning: require() will only touch the filesystem once.
- Code reloading mechanisms for lua also work for glsl, so long as you call newShader() again. I personally don't call newShader() inside each module because it's slow and adds mutable state to the module but it is a good way to share shaders in your code if you're into that.
### Cons
- Filetype detection/syntax highlighting breaks. I personally solve this using vim's modeline support and adding `return [[// vim:ft=glsl` to each top line.
- Lua modules can't be reliably enumerated because of how modular require() is.
- It's theoretically possible to get a lua error by accidentally doing something like `a1[a2[v]]` in your GLSL code.

Comments? I understand this is a relatively intrusive change for a minor thing, so if you get any better ideas I'm all ears.
