### PR TITLE
Fix incorrect range calculation in lighting and shadow rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ end
 - Kyle McLamb @Alloyed
 - @Buckle2000
 - Benoit Giannangeli @giann
+- Ivory @tiwe0

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -176,7 +176,7 @@ function light_world:drawShadows(l,t,w,h,s)
       stencil = function()
         local angle = light.direction - (light.angle / 2.0)
         love.graphics.arc(
-          "fill", (light.x + l/s) * s, (light.y + t/s) * s, light.range, angle, angle + light.angle
+          "fill", (light.x + l/s) * s, (light.y + t/s) * s, light.range * s, angle, angle + light.angle
         )
       end
     })


### PR DESCRIPTION
I’m using this library to develop a game, and I noticed that when scale < 1.0, the light radius appears to shrink proportionally (although technically it doesn’t, it’s barely noticeable to the eye). However, when scale > 1.0, the light radius remains fixed instead of expanding as expected.

This branch fixes that issue.

Additionally, I’m using LÖVE 11.5 (perhaps other versions don’t have this problem, I’m not sure).

Also, the body object in the code doesn’t have a getDimension method, even though it’s mentioned in the documentation.